### PR TITLE
Adding setBasePath method on app, allowing to change basePath at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Options:
 - `docspath` - the path to expose api docs for swagger-ui, etc. Defaults to `/`.
 - `handlers` - either a directory structure for route handlers or a premade object (see *Handlers Object* below).
 
-The base url for the api can also be updated via the `setHost` function on the middleware.
+The base url for the api can also be updated via the `setHost` function on the middleware. The base path can also be updated taht way, using `setBasePath` function on the middleware.
 
 Example:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,13 @@ function mount(options) {
             }
         });
 
+        Object.defineProperty(parent, 'setBasePath', {
+            enumerable: true,
+            value: function (value) {
+                options.api.basePath = value;
+            }
+        });
+
         expressroutes(parent._router, options);
     };
 }


### PR DESCRIPTION
Since host cannot include subpaths (swagger 2.0 specs), this is necessary if your web apps are behind the same url. example: http://my.platform.com/mywebapp/. In that case basePath used for generation is empty and basePath used externally is mywebapp.
