### PR TITLE
Error generated when calling an API with an unallowed method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.0.7
+
+* Fix 405 errors
+
 ### 4.0.0
 
 * Support for `swaggerize-routes` security.

--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -152,7 +152,7 @@ function buildNotAllowedMiddleware(methods) {
     return function (req, res, next) {
         if (methods.indexOf(req.method.toLowerCase()) === -1) {
             res.set('Allow', methods.join(', ').toUpperCase());
-            res.sendStatus(405).end();
+            return res.sendStatus(405).end();
         }
         next();
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swaggerize-express",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "author": "Trevor Livingston <trlivingston@paypal.com>",
   "contributors": [
     "Trevor Livingston <tlivings@gmail.com>",


### PR DESCRIPTION
Calling `res.sendStatus(405).end()` flushes the response, so we should not call `next()` afterwards otherwise an error might get thrown.

This is exactly what happens in some internal projects.
